### PR TITLE
[COR-3699][feat] add mcp server template with examples

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,2 +1,2 @@
 REPO monk-redis
-DIR redis redis-cluster-sentinel redis-cluster-sentinel-haproxy
+DIR redis redis-cluster-sentinel redis-cluster-sentinel-haproxy redis-mcp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
 # monk-redis
+
+Monk templates for Redis deployments and Redis MCP Server integration.
+
+## Available Templates
+
+### Redis
+- **`redis/redis`** - Single Redis instance
+- **`redis-mcp/mcp`** - Redis MCP Server for AI-driven data management
+
+### Redis Cluster
+- **`redis-cluster/stack`** - Redis cluster with master-slave replication and sentinel
+- **`redis-cluster/redis-master`** - Redis master node
+- **`redis-cluster/redis-slave-1`** - Redis slave node 1
+- **`redis-cluster/redis-slave-2`** - Redis slave node 2
+- **`redis-cluster/sentinel`** - Redis sentinel for high availability
+
+### Redis Cluster with HAProxy
+- **`redis-cluster-haproxy/stack`** - Redis cluster with HAProxy load balancer
+
+### Redis MCP Server
+The Redis MCP Server provides a natural language interface for AI applications to interact with Redis data.
+
+#### Main Template
+- **`redis-mcp/mcp`** - Flexible Redis MCP Server with HTTP transport
+
+#### Example Stacks
+- **`example.simple.yaml`** - Simple Redis instance with MCP server
+- **`example.cluster.yaml`** - Redis cluster with sentinel and MCP server
+- **`example.cloud.yaml`** - Redis Cloud with MCP server
+
+## Quick Start
+
+### Basic Redis
+```bash
+monk run redis/redis
+```
+
+### Redis MCP Server
+```bash
+# Run with default settings
+monk run redis-mcp/mcp
+
+# Run with custom Redis connection
+monk run redis-mcp/mcp --set redis_host=your-redis-host --set redis_port=6379
+```
+
+### Redis Cluster
+```bash
+monk run redis-cluster/stack
+```
+
+### Example Stacks
+```bash
+# Simple Redis + MCP
+monk load redis-mcp/example.simple.yaml
+monk run redis-mcp-simple/redis-stack
+
+# Cluster + MCP
+monk load redis-mcp/example.cluster.yaml
+monk run redis-mcp-cluster/cluster-stack
+```
+
+## Features
+
+- **Single Redis Instance** - Basic Redis deployment
+- **Redis Cluster** - High availability with master-slave replication and sentinel
+- **Redis MCP Server** - AI-powered natural language interface for Redis
+- **Multiple Deployment Options** - Local, cluster, and cloud configurations
+- **HTTP Transport** - MCP server accessible on port 8000 for external tools
+
+## Integration
+
+The Redis MCP Server integrates with:
+- **Cursor/VS Code** - Via MCP extension
+- **Claude Desktop** - Via MCP configuration
+- **GitHub Copilot** - Via HTTP transport
+- **OpenAI Agents SDK** - Via HTTP transport
+
+## Documentation
+
+- [Redis MCP Server Documentation](redis-mcp/README.md)
+- [Monk Documentation](https://docs.monk.io/)
+

--- a/redis-mcp/MANIFEST
+++ b/redis-mcp/MANIFEST
@@ -1,0 +1,2 @@
+REPO redis-mcp
+LOAD redis.yml

--- a/redis-mcp/README.md
+++ b/redis-mcp/README.md
@@ -1,0 +1,142 @@
+# Redis MCP Server
+
+The Redis MCP Server is a natural language interface designed for agentic applications to efficiently manage and search data in Redis. It integrates seamlessly with MCP (Model Content Protocol) clients, enabling AI-driven workflows to interact with structured and unstructured data in Redis.
+
+## Features
+
+- **Natural Language Queries**: Enables AI agents to query and update Redis using natural language
+- **Seamless MCP Integration**: Works with any MCP client for smooth communication
+- **Full Redis Support**: Handles hashes, lists, sets, sorted sets, streams, and more
+- **Search & Filtering**: Supports efficient data retrieval and searching in Redis
+- **Scalable & Lightweight**: Designed for high-performance data operations
+- **HTTP Transport**: Exposes MCP server on port 8000 for external access
+
+## Main Template
+
+### `redis-mcp/mcp`
+The main flexible Redis MCP Server that can connect to any Redis instance.
+
+```bash
+# Run with default settings (connects to localhost:6379)
+monk run redis-mcp/mcp
+
+# Run with custom Redis connection
+monk run redis-mcp/mcp --set redis_host=your-redis-host --set redis_port=6379 --set redis_password=your-password
+```
+
+## Example Stacks
+
+### Simple Redis Stack
+Redis instance with MCP server using Monk connections.
+
+```bash
+monk load redis-mcp/example.simple.yaml
+monk run redis-mcp-simple/redis-stack
+```
+
+### Redis Cluster Stack
+Redis cluster with sentinel and MCP server.
+
+```bash
+monk load redis-mcp/example.cluster.yaml
+monk run redis-mcp-cluster/cluster-stack
+```
+
+### Redis Cloud Stack
+Redis Cloud instance with MCP server.
+
+```bash
+monk load redis-mcp/example.cloud.yaml
+monk run redis-mcp-cloud/cloud-stack
+```
+
+## Configuration
+
+The Redis MCP Server supports various configuration options through environment variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MCP_TRANSPORT` | Transport type (stdio, streamable-http, sse) | streamable-http |
+| `MCP_HOST` | Server host for HTTP transport | 0.0.0.0 |
+| `MCP_PORT` | Server port for HTTP transport | 8000 |
+| `REDIS_HOST` | Redis server hostname | localhost |
+| `REDIS_PORT` | Redis server port | 6379 |
+| `REDIS_USERNAME` | Redis username (if applicable) | "" |
+| `REDIS_PWD` | Redis password (if applicable) | "" |
+| `REDIS_SSL` | Enable SSL/TLS connection | false |
+| `REDIS_CA_PATH` | Path to CA certificate | "" |
+| `REDIS_CLUSTER_MODE` | Enable cluster mode | false |
+
+## Integration Examples
+
+
+
+### With VS Code
+
+Add to your `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "redis": {
+      "type": "http",
+      "url": "http://127.0.0.1:8000/mcp/"
+    }
+  }
+}
+```
+
+### With GitHub Copilot
+
+Configure in your settings:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "redis-mcp": {
+        "type": "http",
+        "url": "http://127.0.0.1:8000/mcp/"
+      }
+    }
+  }
+}
+```
+
+## Use Cases
+
+- **AI Assistants**: Enable LLMs to fetch, store, and process data in Redis
+- **Chatbots & Virtual Agents**: Retrieve session data, manage queues, and personalize responses
+- **Data Search & Analytics**: Query Redis for real-time insights and fast lookups
+- **Event Processing**: Manage event streams with Redis Streams
+
+## Example Queries
+
+Once connected, you can ask natural language questions like:
+
+- "Store the entire conversation in a stream"
+- "Cache this item"
+- "Store the session with an expiration time"
+- "Index and search this vector"
+- "Get all users with premium status"
+- "Add this item to the shopping cart"
+
+## Dependencies
+
+The Redis MCP Server uses the official `mcp/redis` Docker image, which is based on the [Redis MCP Server](https://github.com/redis/mcp-redis) project.
+
+## Troubleshooting
+
+### Connection Issues
+- Ensure the Redis instance is running and accessible
+- Check firewall settings if connecting to remote Redis instances
+- Verify credentials for authenticated Redis instances
+
+### Transport Issues
+- The MCP server runs on port 8000 by default
+- Check that the MCP client supports HTTP transport
+- Ensure port 8000 is available and not blocked by firewall
+
+### Cluster Mode
+- When using cluster mode, ensure all cluster nodes are healthy
+- Verify that the sentinel configuration is correct

--- a/redis-mcp/example.cloud.yaml
+++ b/redis-mcp/example.cloud.yaml
@@ -1,0 +1,40 @@
+---
+namespace: redis-mcp-cloud
+
+cloud-stack:
+  defines: process-group
+  metadata:
+    name: Redis Cloud MCP Stack
+    description: Redis Cloud instance with MCP server
+    website: https://github.com/redis/mcp-redis
+    publisher: monk.io
+    icon: https://cdn.icon-icons.com/icons2/2415/PNG/512/redis_original_wordmark_logo_icon_146369.png
+    version: 1.0
+    tags: "redis, mcp, ai, llm, genai, cloud"
+  runnable-list:
+    - redis-cloud-example/stack
+    - redis-mcp-cloud/mcp-cloud
+
+mcp-cloud:
+  defines: runnable
+  inherits: redis-mcp/mcp
+  connections:
+    redis-cloud-db:
+      runnable: redis-cloud-example/redis-database
+      service: db
+  variables:
+    redis_host:
+      value: <- connection-target("redis-cloud-db") entity-state get-member("publicEndpointHost")
+    redis_port:
+      value: <- connection-target("redis-cloud-db") entity-state get-member("publicEndpointPort")
+    redis_username:
+      value: <- connection-target("redis-cloud-db") entity-state get-member("username")
+    redis_password:
+      value: <- connection-target("redis-cloud-db") entity get-member("password_secret") secret
+    redis_ssl:
+      value: true
+  depends:
+    wait-for:
+      runnables:
+        - redis-cloud-example/redis-database
+      timeout: 180 

--- a/redis-mcp/example.cluster.yaml
+++ b/redis-mcp/example.cluster.yaml
@@ -1,0 +1,36 @@
+---
+namespace: redis-mcp-cluster
+
+cluster-stack:
+  defines: process-group
+  metadata:
+    name: Redis Cluster MCP Stack
+    description: Redis cluster with sentinel and MCP server
+    website: https://github.com/redis/mcp-redis
+    publisher: monk.io
+    icon: https://cdn.icon-icons.com/icons2/2415/PNG/512/redis_original_wordmark_logo_icon_146369.png
+    version: 1.0
+    tags: "redis, mcp, ai, llm, genai, cluster, sentinel"
+  runnable-list:
+    - redis-cluster/stack
+    - redis-mcp-cluster/mcp-cluster
+
+mcp-cluster:
+  defines: runnable
+  inherits: redis-mcp/mcp
+  connections:
+    sentinel:
+      runnable: redis-cluster/sentinel
+      service: sentinel
+  variables:
+    redis_host:
+      value: <- connection-hostname("sentinel")
+    redis_port:
+      value: <- connection-port("sentinel")
+    redis_cluster_mode:
+      value: true
+  depends:
+    wait-for:
+      runnables:
+        - redis-cluster/sentinel
+      timeout: 60 

--- a/redis-mcp/example.simple.yaml
+++ b/redis-mcp/example.simple.yaml
@@ -1,0 +1,34 @@
+---
+namespace: redis-mcp-simple
+
+redis-stack:
+  defines: process-group
+  metadata:
+    name: Redis MCP Stack
+    description: Redis instance with MCP server
+    website: https://github.com/redis/mcp-redis
+    publisher: monk.io
+    icon: https://cdn.icon-icons.com/icons2/2415/PNG/512/redis_original_wordmark_logo_icon_146369.png
+    version: 1.0
+    tags: "redis, mcp, ai, llm, genai, single"
+  runnable-list:
+    - redis/redis
+    - redis-mcp-simple/mcp-redis
+
+mcp-redis:
+  defines: runnable
+  inherits: redis-mcp/mcp
+  connections:
+    redis:
+      runnable: redis/redis
+      service: redis-svc
+  variables:
+    redis_host:
+      value: <- connection-hostname("redis")
+    redis_port:
+      value: <- connection-port("redis")
+  depends:
+    wait-for:
+      runnables:
+        - redis/redis
+      timeout: 30 

--- a/redis-mcp/redis.yml
+++ b/redis-mcp/redis.yml
@@ -1,0 +1,80 @@
+---
+namespace: redis-mcp
+
+mcp:
+  defines: runnable
+  metadata:
+    name: Redis MCP Server
+    description: |
+      Flexible Redis MCP Server. Connects to any Redis instance (standalone, cluster, sentinel, or cloud) by setting variables or using Monk connections.
+    website: https://github.com/redis/mcp-redis
+    publisher: monk.io
+    icon: https://cdn.icon-icons.com/icons2/2415/PNG/512/redis_original_wordmark_logo_icon_146369.png
+    version: 1.0
+    tags: "redis, mcp, ai, llm, genai"
+  variables:
+    mcp_transport:
+      env: MCP_TRANSPORT
+      type: string
+      value: streamable-http
+    mcp_host:
+      env: MCP_HOST
+      type: string
+      value: 0.0.0.0
+    mcp_port:
+      env: MCP_PORT
+      type: int
+      value: 8000
+    mcp_publish:
+      type: bool
+      value: false
+    redis_host:
+      env: REDIS_HOST
+      type: string
+      value: localhost
+    redis_port:
+      env: REDIS_PORT
+      type: int
+      value: 6379
+    redis_username:
+      env: REDIS_USERNAME
+      type: string
+      value: ""
+    redis_password:
+      env: REDIS_PWD
+      type: string
+      value: ""
+    redis_ssl:
+      env: REDIS_SSL
+      type: bool
+      value: false
+    redis_ca_path:
+      env: REDIS_CA_PATH
+      type: string
+      value: ""
+    redis_cluster_mode:
+      env: REDIS_CLUSTER_MODE
+      type: bool
+      value: false
+  containers:
+    mcp-server:
+      image: mcp/redis
+      image-tag: latest
+      environment:
+        - MCP_TRANSPORT=${mcp_transport}
+        - MCP_HOST=${mcp_host}
+        - MCP_PORT=${mcp_port}
+        - REDIS_HOST=${redis_host}
+        - REDIS_PORT=${redis_port}
+        - REDIS_USERNAME=${redis_username}
+        - REDIS_PWD=${redis_password}
+        - REDIS_SSL=${redis_ssl}
+        - REDIS_CA_PATH=${redis_ca_path}
+        - REDIS_CLUSTER_MODE=${redis_cluster_mode}
+  services:
+    mcp:
+      container: mcp-server
+      port: 8000
+      protocol: tcp
+      publish: false
+      host-port: 8000 


### PR DESCRIPTION
This pull request introduces a new Redis MCP Server integration to the Monk templates, enhancing Redis deployments with AI-driven data management capabilities. Key changes include updates to the `README.md`, addition of new templates and configurations for Redis MCP Server, and detailed documentation for integration and usage.

### Redis MCP Server Integration

* **Added Redis MCP Server template and configuration**: Introduced `redis-mcp/mcp` as a flexible template for connecting to various Redis instances, with support for natural language queries and AI-driven workflows. (`redis-mcp/redis.yml`, [redis-mcp/redis.ymlR1-R80](diffhunk://#diff-a63bc1bee90129fd37b9620a939eb6e9f79a602ed927c1725dd99fe9de4cf500R1-R80))
* **Updated `README.md`**: Documented the Redis MCP Server and its features, including example stacks, integration options, and use cases. (`README.md`, [README.mdR2-R84](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R84))
* **Created Redis MCP Server-specific documentation**: Added a dedicated `redis-mcp/README.md` file detailing features, configuration options, and integration examples. (`redis-mcp/README.md`, [redis-mcp/README.mdR1-R142](diffhunk://#diff-502e8277ff0d9209dac100457446105e303b7f696706c40974a7ccfac72d80e0R1-R142))

### Example Stacks for Redis MCP Server

* **Added example templates for Redis MCP Server stacks**: Introduced `example.simple.yaml`, `example.cluster.yaml`, and `example.cloud.yaml` for deploying Redis MCP Server in standalone, cluster, and cloud environments. (`redis-mcp/example.simple.yaml`, [[1]](diffhunk://#diff-3cb6bcac6ae5e099c2ae3e76662864cc3c9acebfa7a8a465cd3e79b5e4dea1c7R1-R34); `redis-mcp/example.cluster.yaml`, [[2]](diffhunk://#diff-d9778212ddf64d74aae64d6a15e6e349cbe1c1c134ba994fe87d208845473296R1-R36); `redis-mcp/example.cloud.yaml`, [[3]](diffhunk://#diff-d98b7c5737d88688a42994d9c5339fc128b636cb389e00a06f6c0291a459633fR1-R40)

### Manifest Updates

* **Updated `MANIFEST` file**: Added `redis-mcp` directory to the list of available templates. (`MANIFEST`, [MANIFESTL2-R2](diffhunk://#diff-bd43a7da36c1cfe19eebcdf7324f4e3aeec37a5c48ce180964e8c68c4abefc2cL2-R2))
* **Created `redis-mcp/MANIFEST`**: Defined repository and load configuration for Redis MCP Server. (`redis-mcp/MANIFEST`, [redis-mcp/MANIFESTR1-R2](diffhunk://#diff-76f671204e367141d97b0cb810cb9d0ad1c51e50fe665ab71993270d8fa10b08R1-R2))