### PR TITLE
Replace bitnami image references with bitnamilegacy

### DIFF
--- a/redis-cluster-sentinel-haproxy/redis.yml
+++ b/redis-cluster-sentinel-haproxy/redis.yml
@@ -35,7 +35,7 @@ base:
     redis:
       paths:
         - <- `${monk-volume-path}/redis/${redis_instance_name}:/bitnami/redis/data`
-      image: bitnami/redis
+      image: bitnamilegacy/redis
 
 redis-master:
   defines: runnable
@@ -231,7 +231,7 @@ sentinel:
       value: <- connection-port("redis-master")
   containers:
     sentinel:
-      image: bitnami/redis-sentinel
+      image: bitnamilegacy/redis-sentinel
   depends:
     wait-for:
       runnables:

--- a/redis-cluster-sentinel/redis.yml
+++ b/redis-cluster-sentinel/redis.yml
@@ -35,7 +35,7 @@ base:
     redis:
       paths:
         - <- `${monk-volume-path}/redis/${redis_instance_name}:/bitnami/redis/data`
-      image: bitnami/redis
+      image: bitnamilegacy/redis
 
 redis-master:
   defines: runnable
@@ -231,7 +231,7 @@ sentinel:
       value: <- connection-port("redis-master")
   containers:
     sentinel:
-      image: bitnami/redis-sentinel
+      image: bitnamilegacy/redis-sentinel
   depends:
     wait-for:
       runnables:

--- a/redis/redis.yml
+++ b/redis/redis.yml
@@ -35,7 +35,7 @@ base:
     redis:
       paths:
         - <- `${monk-volume-path}/redis/${redis_instance_name}:/bitnami/redis/data`
-      image: bitnami/redis
+      image: bitnamilegacy/redis
 
 
 redis:


### PR DESCRIPTION
This PR replaces 'image: docker.io/bitnami/' and 'image: bitnami/' with their 'bitnamilegacy' equivalents, as per organization migration.